### PR TITLE
Issue 79

### DIFF
--- a/src/main/java/net/objecthunter/exp4j/ExpressionBuilder.java
+++ b/src/main/java/net/objecthunter/exp4j/ExpressionBuilder.java
@@ -33,6 +33,7 @@ import net.objecthunter.exp4j.tokenizer.Token;
  * Users should create new {@link Expression} instances using this factory class.
  */
 public class ExpressionBuilder {
+    private static final Pattern VAR_NAME_PATTERN = Pattern.compile("[\\s+\\-*/%^!#§$&:~<>|=¬]+");
 
     private final String expression;
 
@@ -232,7 +233,6 @@ public class ExpressionBuilder {
         return expression;
     }
 
-    private static final Pattern VAR_NAME_PATTERN = Pattern.compile("[\\s+\\-*/%^!#§$&:~<>|=¬]+");
     private static void checkVariableName(String vname) throws IllegalArgumentException {
         if (VAR_NAME_PATTERN.matcher(vname).matches()) {
             throw new IllegalArgumentException("Variable names can't contain non ASCII letters");

--- a/src/main/java/net/objecthunter/exp4j/ExpressionBuilder.java
+++ b/src/main/java/net/objecthunter/exp4j/ExpressionBuilder.java
@@ -16,12 +16,12 @@
 
 package net.objecthunter.exp4j;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import net.objecthunter.exp4j.function.Function;
 import net.objecthunter.exp4j.function.Functions;
 import net.objecthunter.exp4j.operator.Operator;
@@ -101,9 +101,13 @@ public class ExpressionBuilder {
      *
      * @param variableNames variables to use
      * @return the ExpressionBuilder instance
+     * @throws IllegalArgumentException if the variable name contains spaces or
+     * operator characters
      */
     public ExpressionBuilder variables(Set<String> variableNames) {
-        this.variableNames.addAll(variableNames);
+        for (String vname : variableNames) {
+            variable(vname);
+        }
         return this;
     }
 
@@ -113,9 +117,13 @@ public class ExpressionBuilder {
      *
      * @param variableNames variables to use
      * @return the ExpressionBuilder instance
+     * @throws IllegalArgumentException if the variable name contains spaces or
+     * operator characters
      */
     public ExpressionBuilder variables(String ... variableNames) {
-        Collections.addAll(this.variableNames, variableNames);
+        for (String vname : variableNames) {
+            variable(vname);
+        }
         return this;
     }
 
@@ -125,8 +133,11 @@ public class ExpressionBuilder {
      *
      * @param variableName variable to use
      * @return the ExpressionBuilder instance
+     * @throws IllegalArgumentException if the variable name contains spaces or
+     * operator characters
      */
     public ExpressionBuilder variable(String variableName) {
+        checkVariableName(variableName);
         this.variableNames.add(variableName);
         return this;
     }
@@ -219,6 +230,13 @@ public class ExpressionBuilder {
     @Override
     public String toString() {
         return expression;
+    }
+
+    private static final Pattern VAR_NAME_PATTERN = Pattern.compile("[ +\\-*/%^!#§$&:~<>|=¬]+");
+    private static void checkVariableName(String vname) throws IllegalArgumentException {
+        if (VAR_NAME_PATTERN.matcher(vname).matches()) {
+            throw new IllegalArgumentException("Variable names can't contain non ASCII letters");
+        }
     }
 
 }

--- a/src/main/java/net/objecthunter/exp4j/ExpressionBuilder.java
+++ b/src/main/java/net/objecthunter/exp4j/ExpressionBuilder.java
@@ -232,7 +232,7 @@ public class ExpressionBuilder {
         return expression;
     }
 
-    private static final Pattern VAR_NAME_PATTERN = Pattern.compile("[ +\\-*/%^!#§$&:~<>|=¬]+");
+    private static final Pattern VAR_NAME_PATTERN = Pattern.compile("[\\s+\\-*/%^!#§$&:~<>|=¬]+");
     private static void checkVariableName(String vname) throws IllegalArgumentException {
         if (VAR_NAME_PATTERN.matcher(vname).matches()) {
             throw new IllegalArgumentException("Variable names can't contain non ASCII letters");

--- a/src/test/java/net/objecthunter/exp4j/ExpressionBuilderTest.java
+++ b/src/test/java/net/objecthunter/exp4j/ExpressionBuilderTest.java
@@ -2899,4 +2899,30 @@ public class ExpressionBuilderTest {
         Expression e = builder.functions().build();
         assertEquals(1, e.evaluate(), 1e-9);
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIssue79() {
+        //https://github.com/fasseg/exp4j/issues/79
+        new ExpressionBuilder("field-plus+field-minus" )
+                          .variables("field-plus","field-minus")
+                          .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIssue79_2() {
+        //https://github.com/fasseg/exp4j/issues/79
+        new ExpressionBuilder("hello world * 3" )
+                      .variable("hello world")
+                      .build();
+    }
+
+    @Test
+    public void testIssue79_3() {
+        //https://github.com/fasseg/exp4j/issues/79
+        Expression e = new ExpressionBuilder("hello world * 3" )
+                      .variables("hello", "world")
+                      .build();
+        assertNotNull(e);
+    }
+
 }


### PR DESCRIPTION
This issue is actually a pretty silly one, and it's amazing that hasn't come up before... the fact is there are no explicit rules for variable names in `exp4j`. From now on:

- Variables can't contain whitespace characters (matching `\s`)
- Variables can't be function names (this will fail on build)
- Variables can't contain characters that correspond to Operators https://github.com/RiddlerArgentina/exp4j/blob/75197148b6d3744ce052b8291d2cd7b72ab7fd92/src/main/java/net/objecthunter/exp4j/operator/Operator.java#L75-L80

I would like to thank @nrmohta for submitting this issue.